### PR TITLE
fix: surface sdk versions from version.swift

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -2,6 +2,6 @@
 version_scheme = "semver"
 version = "2.0.0"
 version_files = [
-  "Sources/Primer3DS/Classes/version.swift:let Primer3DSVersion",
+  "Sources/Primer3DS/Classes/version.swift:let Primer3DSSDKVersion",
   "Primer3DS.podspec:s.version"
 ]

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -47,7 +47,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
-          base: master
+          base: main
           branch: release/next
           delete-branch: true
           title: Release ${{ env.TO_VERSION }}

--- a/Example/Primer3DS.xcodeproj/project.pbxproj
+++ b/Example/Primer3DS.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Primer3DSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Primer3DSTests.swift */; };
+		F0398B462ADFF62F00775C5F /* VersionUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0398B452ADFF62F00775C5F /* VersionUtilsTests.swift */; };
 		F9E39A13F614499D63B6FD51 /* Pods_Primer3DS_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C3499BAC61D75AF0AB90C58 /* Pods_Primer3DS_Tests.framework */; };
 /* End PBXBuildFile section */
 
@@ -53,6 +54,8 @@
 		B2F6483A51041DDF40A0CB01 /* Pods_Primer3DS_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Primer3DS_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B75EA0E1EBA9402C2949415A /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		CC2616CC59FFB068E592814A /* Pods-Primer3DS_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Primer3DS_Example.release.xcconfig"; path = "Target Support Files/Pods-Primer3DS_Example/Pods-Primer3DS_Example.release.xcconfig"; sourceTree = "<group>"; };
+		F0398B452ADFF62F00775C5F /* VersionUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionUtilsTests.swift; sourceTree = "<group>"; };
+		F0398B472ADFF8FD00775C5F /* ThreeDS_SDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ThreeDS_SDK.xcframework; path = ../Sources/Frameworks/ThreeDS_SDK.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -126,6 +129,7 @@
 				04B6FF942AA875A400779407 /* Primer3DSChallengeTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 				04AC5AB42AA8AD9E00EE5FD0 /* StringHelpersTests.swift */,
+				F0398B452ADFF62F00775C5F /* VersionUtilsTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -162,6 +166,7 @@
 		7E98867F42DF09369BCDC8A6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F0398B472ADFF8FD00775C5F /* ThreeDS_SDK.xcframework */,
 				B2F6483A51041DDF40A0CB01 /* Pods_Primer3DS_Example.framework */,
 				2C3499BAC61D75AF0AB90C58 /* Pods_Primer3DS_Tests.framework */,
 			);
@@ -353,6 +358,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				04AC5AB52AA8AD9E00EE5FD0 /* StringHelpersTests.swift in Sources */,
+				F0398B462ADFF62F00775C5F /* VersionUtilsTests.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* Primer3DSTests.swift in Sources */,
 				04B6FF952AA875A400779407 /* Primer3DSChallengeTests.swift in Sources */,
 				04B6FF972AA875BB00779407 /* Mocks.swift in Sources */,

--- a/Example/Tests/VersionUtilsTests.swift
+++ b/Example/Tests/VersionUtilsTests.swift
@@ -1,0 +1,32 @@
+//
+//  VersionUtilsTests.swift
+//  Primer3DS_Tests
+//
+//  Created by Niall Quinn on 18/10/23.
+//  Copyright © 2023 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import Primer3DS
+import ThreeDS_SDK
+
+final class VersionUtilsTests: XCTestCase {
+
+    func test_wrapperVersionNumber() throws {
+        XCTAssertEqual(VersionUtils.wrapperSDKVersionNumber, Primer3DSVersion)
+    }
+    
+    func test_3DSVersionNumber() throws {
+        XCTAssertEqual(VersionUtils.threeDsSdkVersionNumber, NetceteraSDKVersion)
+    }
+
+    func test_3DSMatchesNetcetera() throws {
+        guard let netceteraVersion = Bundle(for: ThreeDS2ServiceSDK.self)
+            .infoDictionary?["CFBundleShortVersionString"] as? String else {
+            XCTFail("Could not locate ThreeDS Bundle")
+            return
+        }
+        
+        XCTAssertEqual(netceteraVersion, VersionUtils.threeDsSdkVersionNumber)
+    }
+}

--- a/Example/Tests/VersionUtilsTests.swift
+++ b/Example/Tests/VersionUtilsTests.swift
@@ -13,7 +13,7 @@ import ThreeDS_SDK
 final class VersionUtilsTests: XCTestCase {
 
     func test_wrapperVersionNumber() throws {
-        XCTAssertEqual(VersionUtils.wrapperSDKVersionNumber, Primer3DSVersion)
+        XCTAssertEqual(VersionUtils.wrapperSDKVersionNumber, Primer3DSSDKVersion)
     }
     
     func test_3DSVersionNumber() throws {

--- a/Example/Tests/VersionUtilsTests.swift
+++ b/Example/Tests/VersionUtilsTests.swift
@@ -17,7 +17,7 @@ final class VersionUtilsTests: XCTestCase {
     }
     
     func test_3DSVersionNumber() throws {
-        XCTAssertEqual(VersionUtils.threeDsSdkVersionNumber, NetceteraSDKVersion)
+        XCTAssertEqual(VersionUtils.threeDSSDKVersionNumber, NetceteraSDKVersion)
     }
 
     func test_3DSMatchesNetcetera() throws {
@@ -27,6 +27,6 @@ final class VersionUtilsTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(netceteraVersion, VersionUtils.threeDsSdkVersionNumber)
+        XCTAssertEqual(netceteraVersion, VersionUtils.threeDSSDKVersionNumber)
     }
 }

--- a/Sources/Primer3DS/Classes/Primer3DS.swift
+++ b/Sources/Primer3DS/Classes/Primer3DS.swift
@@ -7,10 +7,10 @@ import UIKit
 
 public class Primer3DS: NSObject, Primer3DSProtocol {
 
-    public static let version: String? = Bundle(identifier: "org.cocoapods.Primer3DS")?.infoDictionary?["CFBundleShortVersionString"] as? String
-    public static let hardcodedVersion: String = "1.2.1"
+    public static var version: String = VersionUtils.primer3DSVersionNumber
+    public static var hardcodedVersion = VersionUtils.primer3DSVersionNumber
     public static let threeDsSdkProvider: String = "NETCETERA"
-    public static var threeDsSdkVersion: String? = Bundle(identifier: "com.netcetera.ThreeDS-SDK")?.infoDictionary?["CFBundleShortVersionString"] as? String
+    public static var threeDsSdkVersion = VersionUtils.wrappedSdkVersionNumber
     public static let supportedSchemeId = "A999999999"
     
     public private(set) var environment: Environment

--- a/Sources/Primer3DS/Classes/Primer3DS.swift
+++ b/Sources/Primer3DS/Classes/Primer3DS.swift
@@ -7,10 +7,13 @@ import UIKit
 
 public class Primer3DS: NSObject, Primer3DSProtocol {
 
-    public static var version: String = VersionUtils.primer3DSVersionNumber
-    public static var hardcodedVersion = VersionUtils.primer3DSVersionNumber
+    public static var version: String = VersionUtils.wrapperSDKVersionNumber
+    public static var threeDsSdkVersion = VersionUtils.threeDsSdkVersionNumber
+    
+    @available(*, deprecated, message: "use `version` instead")
+    public static var hardcodedVersion = VersionUtils.wrapperSDKVersionNumber
+    
     public static let threeDsSdkProvider: String = "NETCETERA"
-    public static var threeDsSdkVersion = VersionUtils.wrappedSdkVersionNumber
     public static let supportedSchemeId = "A999999999"
     
     public private(set) var environment: Environment

--- a/Sources/Primer3DS/Classes/Primer3DS.swift
+++ b/Sources/Primer3DS/Classes/Primer3DS.swift
@@ -8,7 +8,7 @@ import UIKit
 public class Primer3DS: NSObject, Primer3DSProtocol {
 
     public static var version: String = VersionUtils.wrapperSDKVersionNumber
-    public static var threeDsSdkVersion = VersionUtils.threeDsSdkVersionNumber
+    public static var threeDsSdkVersion = VersionUtils.threeDSSDKVersionNumber
     
     @available(*, deprecated, message: "use `version` instead")
     public static var hardcodedVersion = VersionUtils.wrapperSDKVersionNumber

--- a/Sources/Primer3DS/Classes/VersionUtils.swift
+++ b/Sources/Primer3DS/Classes/VersionUtils.swift
@@ -23,7 +23,7 @@ struct VersionUtils {
      
      The version specified as `NetceteraSDKVersion` in the file `"sources/version.swift"` will be returned.
      */
-    static var threeDsSdkVersionNumber: String {
+    static var threeDSSDKVersionNumber: String {
         NetceteraSDKVersion
     }
 }

--- a/Sources/Primer3DS/Classes/VersionUtils.swift
+++ b/Sources/Primer3DS/Classes/VersionUtils.swift
@@ -12,10 +12,10 @@ struct VersionUtils {
     /**
      Returns the version string of the _wrapper_ sdk in the format `"major.minor.patch"`
      
-     The version specified as `Primer3DSVersion` in the file `"sources/version.swift"` will be returned.
+     The version specified as `Primer3DSSDKVersion` in the file `"sources/version.swift"` will be returned.
      */
     static var wrapperSDKVersionNumber: String {
-        Primer3DSVersion
+        Primer3DSSDKVersion
     }
     
     /**

--- a/Sources/Primer3DS/Classes/VersionUtils.swift
+++ b/Sources/Primer3DS/Classes/VersionUtils.swift
@@ -1,0 +1,29 @@
+//
+//  VersionUtils.swift
+//  Primer3DS
+//
+//  Created by Niall Quinn on 17/10/23.
+//
+
+import Foundation
+
+struct VersionUtils {
+    
+    /**
+     Returns the version string of the _wrapper_ sdk in the format `"major.minor.patch"`
+     
+     The version specified as `Primer3DSVersion` in the file `"sources/version.swift"` will be returned.
+     */
+    static var primer3DSVersionNumber: String {
+        Primer3DSVersion
+    }
+    
+    /**
+     Returns the version string of the _wrapped_ sdk in the format `"major.minor.patch"`
+     
+     The version specified as `NetceteraSDKVersion` in the file `"sources/version.swift"` will be returned.
+     */
+    static var wrappedSdkVersionNumber: String {
+        NetceteraSDKVersion
+    }
+}

--- a/Sources/Primer3DS/Classes/VersionUtils.swift
+++ b/Sources/Primer3DS/Classes/VersionUtils.swift
@@ -14,7 +14,7 @@ struct VersionUtils {
      
      The version specified as `Primer3DSVersion` in the file `"sources/version.swift"` will be returned.
      */
-    static var primer3DSVersionNumber: String {
+    static var wrapperSDKVersionNumber: String {
         Primer3DSVersion
     }
     
@@ -23,7 +23,7 @@ struct VersionUtils {
      
      The version specified as `NetceteraSDKVersion` in the file `"sources/version.swift"` will be returned.
      */
-    static var wrappedSdkVersionNumber: String {
+    static var threeDsSdkVersionNumber: String {
         NetceteraSDKVersion
     }
 }

--- a/Sources/Primer3DS/Classes/version.swift
+++ b/Sources/Primer3DS/Classes/version.swift
@@ -1,1 +1,2 @@
 let Primer3DSVersion = "2.0.0"
+let NetceteraSDKVersion = "2.3.74"

--- a/Sources/Primer3DS/Classes/version.swift
+++ b/Sources/Primer3DS/Classes/version.swift
@@ -1,2 +1,2 @@
-let Primer3DSVersion = "2.0.0"
+let Primer3DSSDKVersion = "2.0.0"
 let NetceteraSDKVersion = "2.3.74"


### PR DESCRIPTION
- Surfaces the wrapper sdk version from the harcoded version.swift file via the public interface.
- Hardcodes the Netcetera SDK version to be surfaced via the public interface.
- Adds unit tests for version numbers
- Adds unit test to check hardcoded netcetera version matches the xcframework
- Deprecates `hardcodedVersion` to be removed later.

