### PR TITLE
chore: fix syntax for branch

### DIFF
--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     # Patterns matched against refs/heads
     branches:
-      - release/next
+      - 'release/**'
     types: [ closed ]
 
 jobs:

--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -1,6 +1,7 @@
 name: Post Release PR Merge
 
 on:
+  workflow_dispatch:
   pull_request:
     # Patterns matched against refs/heads
     branches:

--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -1,11 +1,11 @@
 name: Post Release PR Merge
 
-on: workflow_dispatch
-  # pull_request:
-  #   # Patterns matched against refs/heads
-  #   branches:
-  #     - release/next
-  #   types: [ closed ]
+on:
+  pull_request:
+    # Patterns matched against refs/heads
+    branches:
+      - release/next
+    types: [ closed ]
 
 jobs:
   release_merge:


### PR DESCRIPTION
The branch name should be supplied as a string. See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-based-on-the-head-or-base-branch-of-a-pull-request